### PR TITLE
Update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "uuid"      : "^2.0.2",
         "vow"       : "^0.4.7",
         "vow-queue" : "^0.4.1",
-        "glob"      : "^4.3.1"
+        "glob"      : "^7.0.5"
     },
     "devDependencies": {
         "nodeunit" : "",


### PR DESCRIPTION
Currently installing `vow-fs` gives a warning:

```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

This PR updates the `glob` dependency to the most recent version which uses an updated `minimatch` version as well.

I ran the tests after the change and they all still pass.
